### PR TITLE
Updates requirements to accept symfony/finder ~4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "symfony/finder": "~2.6|~3.0"
+        "symfony/finder": "~2.6|~3.0|~4.0"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^3.2",


### PR DESCRIPTION
Symfony/finder 4+ should be compatible 100% so it's just accepting it.